### PR TITLE
bump min version of bootstrap-ie8 to 4.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "axios": "^0.18.0",
     "babel-polyfill": "^6.26.0",
     "bootstrap": "^4.1.3",
-    "bootstrap-ie8": "^4.1.3",
+    "bootstrap-ie8": "^4.3.1",
     "bootstrap-vue": "^2.0.0-rc.10",
     "jquery": "^3.3.1",
     "mo-js": "^0.288.2",


### PR DESCRIPTION
REF: https://github.com/coliff/bootstrap-ie8/releases